### PR TITLE
dnsmasq: add 'scriptarp' option

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -866,6 +866,7 @@ dnsmasq_start()
 	append_bool "$cfg" allservers "--all-servers"
 	append_bool "$cfg" noping "--no-ping"
 	append_bool "$cfg" rapidcommit "--dhcp-rapid-commit"
+	append_bool "$cfg" scriptarp "--script-arp"
 
 	append_parm "$cfg" logfacility "--log-facility"
 
@@ -915,6 +916,7 @@ dnsmasq_start()
 	config_get user_dhcpscript $cfg dhcpscript
 	if has_handler || [ -n "$user_dhcpscript" ]; then
 		xappend "--dhcp-script=$DHCPSCRIPT"
+		xappend "--script-arp"
 	fi
 
 	config_get leasefile $cfg leasefile "/tmp/dhcp.leases"


### PR DESCRIPTION
Add option 'scriptarp' to uci dnsmasq config to enable --script-arp functions.
The default setting is false, meaning any scripts in `/etc/hotplug.d/neigh` intended to be triggered by `/usr/lib/dnsmasq/dhcp-script.sh` will fail to execute.

Also enable --script-arp if has_handlers returns true.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
